### PR TITLE
Fix macos

### DIFF
--- a/modules/psd/psd_texture.cpp
+++ b/modules/psd/psd_texture.cpp
@@ -143,6 +143,7 @@ void PSDTexture::parse() {
 	const std::wstring rawFile = L"";
 	Ref<StreamPeerBuffer> file;
 	file.instantiate();
+	file->set_big_endian(true);
 	file->set_data_array(data);
 	MallocAllocator allocator;
 
@@ -289,17 +290,15 @@ void PSDTexture::parse() {
 			// get the layer name.
 			// Unicode data is preferred because it is not truncated by Photoshop, but unfortunately it is optional.
 			// fall back to the ASCII name in case no Unicode name was found.
-			std::wstringstream ssLayerName;
+			String layerName;
 			if (layer->utf16Name)
 			{
-				ssLayerName << reinterpret_cast<wchar_t*>(layer->utf16Name);
+				layerName.parse_utf16(layer->utf16Name);
 			}
 			else
 			{
-				ssLayerName << layer->name.c_str();
+				layerName = layer->name.c_str();
 			}
-			std::wstring wslayerName = ssLayerName.str();
-			const wchar_t* layerName = wslayerName.c_str();
 
 			// at this point, image8, image16 or image32 store either a 8-bit, 16-bit, or 32-bit image, respectively.
 			// the image data is stored in interleaved RGB or RGBA, and has the size "document->width*document->height".
@@ -338,7 +337,7 @@ void PSDTexture::set_data(const Vector<uint8_t> &p_data) {
 
 }
 
-void PSDTexture::ExportLayer(const wchar_t* p_name, unsigned int p_width, unsigned int p_height, const uint8_t* p_data, int p_channel_type)
+void PSDTexture::ExportLayer(String p_name, unsigned int p_width, unsigned int p_height, const uint8_t* p_data, int p_channel_type)
 {
 	if (p_channel_type == -1) {
 		layers[String(p_name)] = Ref<Texture>();
@@ -372,8 +371,7 @@ void PSDTexture::ExportLayer(const wchar_t* p_name, unsigned int p_width, unsign
 
 	Ref<Texture> texture_layer = ImageTexture::create_from_image(image_layer);
 
-	layers[String(p_name)] = texture_layer;
-
+	layers[p_name] = texture_layer;
 }
 
 Array PSDTexture::get_layer_names() const {

--- a/modules/psd/psd_texture.h
+++ b/modules/psd/psd_texture.h
@@ -95,7 +95,7 @@ protected:
 
 	void parse();
 
-	void ExportLayer(const wchar_t* p_name, unsigned int p_width, unsigned int p_height, const uint8_t* p_data, int p_channel_type);
+	void ExportLayer(String p_name, unsigned int p_width, unsigned int p_height, const uint8_t* p_data, int p_channel_type);
 
 	void clear_data();
 

--- a/thirdparty/psd_sdk/PsdLayer.h
+++ b/thirdparty/psd_sdk/PsdLayer.h
@@ -22,7 +22,7 @@ struct Layer
 {
 	Layer* parent;						///< The layer's parent layer, if any.
 	util::FixedSizeString name;			///< The ASCII name of the layer. Truncated to 31 characters in PSD files.
-	uint16_t* utf16Name;				///< The UTF16 name of the layer.
+	char16_t* utf16Name;				///< The UTF16 name of the layer.
 
 	int32_t top;						///< Top coordinate of the rectangle that encloses the layer.
 	int32_t left;						///< Left coordinate of the rectangle that encloses the layer.

--- a/thirdparty/psd_sdk/PsdParseLayerMaskSection.cpp
+++ b/thirdparty/psd_sdk/PsdParseLayerMaskSection.cpp
@@ -714,7 +714,7 @@ namespace
 						// PSD Unicode strings store 4 bytes for the number of characters, NOT bytes, followed by
 						// 2-byte UTF16 Unicode data without the terminating null.
 						const uint32_t characterCountWithoutNull = fileUtil::ReadFromFileBE<uint32_t>(reader);
-						layer->utf16Name = memoryUtil::AllocateArray<uint16_t>(allocator, characterCountWithoutNull + 1u);
+						layer->utf16Name = memoryUtil::AllocateArray<char16_t>(allocator, characterCountWithoutNull + 1u);
 
 						for (uint32_t c = 0u; c < characterCountWithoutNull; ++c)
 						{


### PR DESCRIPTION
This PR fixes two problems with this plugin on macos
1) psd isn't loading because of different endianness. Event the first few bytes with a magic control bytes treat in a wrong order, no matter on what platform the psd file was created.
2) on macos wchar_t is a utf32 char, not utf16. So, reinterpret cast uint16_t* to wchar_t* gives incorrect layer's names in the editor.

I didn't find any other problems on macos.
I haven't tested PR on windows, but I believe that these changes should be safe and shouldn't break anything. But I will be grateful if you can check them before merge.
Thanks!